### PR TITLE
Basic PHP 8.2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/.idea/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
-    "name": "proj4php/proj4php",
+    "name": "moxio/proj4php",
     "license": "LGPL-2.1",
+    "version": "3.0.0",
     "type": "library",
     "description": "A PHP-Class for geographic coordinates transformation using proj4 definitions, thanks to a translation from Proj4JS",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,17 @@
 {
     "name": "moxio/proj4php",
     "license": "LGPL-2.1",
-    "version": "3.0.0",
     "type": "library",
-    "description": "A PHP-Class for geographic coordinates transformation using proj4 definitions, thanks to a translation from Proj4JS",
+    "description": "A Fork of the proj4php project, patched to not create any php 8.2 deprecation warnings",
     "keywords": [
         "geographic",
         "coordinates",
         "proj4",
         "proj4js"
     ],
+    "replace": {
+        "proj4php/proj4php":"2.0.12"
+    },
     "homepage": "https://github.com/proj4php/proj4php",
     "authors": [
         {

--- a/src/LongLat.php
+++ b/src/LongLat.php
@@ -9,6 +9,7 @@ namespace proj4php;
  * and Richard Greenwood rich@greenwoodmap.com 
  * License: LGPL as per: http://www.gnu.org/copyleft/lesser.html 
  */
+#[\AllowDynamicProperties]
 class LongLat
 {
     public function init()

--- a/src/Proj.php
+++ b/src/Proj.php
@@ -12,6 +12,7 @@ namespace proj4php;
 
 use Exception;
 
+#[\AllowDynamicProperties]
 class Proj
 {
     /**

--- a/src/Proj.php
+++ b/src/Proj.php
@@ -375,7 +375,7 @@ class Proj
         }
 
         // The class name for the projection code
-        $classname = '\\proj4php\\projCode\\' . ucfirst($projName);
+        $classname = '\\proj4php\\projCode\\' . ucfirst($projName ?? "");
 
         if (class_exists($classname)) {
             // Instantiate the class then store it in the global static (for now) $prog array.

--- a/src/projCode/Aea.php
+++ b/src/projCode/Aea.php
@@ -37,6 +37,7 @@ use proj4php\Proj4php;
 use proj4php\Common;
 use proj4php\Point;
 
+#[\AllowDynamicProperties]
 class Aea
 {
     public $a;

--- a/src/projCode/Lcc.php
+++ b/src/projCode/Lcc.php
@@ -36,6 +36,7 @@ use proj4php\Proj4php;
 use proj4php\Common;
 use proj4php\Point;
 
+#[\AllowDynamicProperties]
 class Lcc
 {
     // All public properties are referenced externally in simple tests.

--- a/src/projCode/Merc.php
+++ b/src/projCode/Merc.php
@@ -46,6 +46,7 @@ namespace proj4php\projCode;
 use proj4php\Proj4php;
 use proj4php\Common;
 
+#[\AllowDynamicProperties]
 class Merc
 {
     public $a;

--- a/src/projCode/Sterea.php
+++ b/src/projCode/Sterea.php
@@ -14,6 +14,7 @@ use proj4php\Proj4php;
 use proj4php\Common;
 use proj4php\Point;
 
+#[\AllowDynamicProperties]
 class Sterea extends Gauss
 {
     public $R2;

--- a/src/projCode/Tmerc.php
+++ b/src/projCode/Tmerc.php
@@ -31,6 +31,7 @@ namespace proj4php\projCode;
 use proj4php\Proj4php;
 use proj4php\Common;
 
+#[\AllowDynamicProperties]
 class Tmerc
 {
     public $a;

--- a/src/projCode/Utm.php
+++ b/src/projCode/Utm.php
@@ -35,6 +35,7 @@ namespace proj4php\projCode;
 use proj4php\Proj4php;
 use proj4php\Common;
 
+#[\AllowDynamicProperties]
 class Utm
 {
     // public $dependsOn = 'tmerc';


### PR DESCRIPTION
This update will remove the warnings that come from PHP 8.2. 

This does still have some downsides however:
* The `AllowDynamicProperties` attributes is supported from PHP 8.*
* Updating to PHP 8 requires you to also update PHPUnit (from 4.0 to atleast 8.0)
* The current PHP in the composer.json is wrong. It is  `>=7.2`, but it clearly does not support 8 and up
* Newer versions of `composer` do not support the older `autoload` implemention still used in this project

And the biggest downside: This is still just a patch instead of full support. 


But using this library in a project, that runs 8.2, won't give you any deprecation warnings.   